### PR TITLE
Don't write to statement cache twice

### DIFF
--- a/core/src/main/java/com/griefcraft/sql/Database.java
+++ b/core/src/main/java/com/griefcraft/sql/Database.java
@@ -339,7 +339,8 @@ public abstract class Database {
         try {
             if (useStatementCache) {
                 Statistics.addQuery();
-                return statementCache.get(sql, () -> prepareInternal(sql, returnGeneratedKeys));
+                final PreparedStatement p = statementCache.getIfPresent(sql);
+				if(p != null) return p;
             }
 
             return prepareInternal(sql, returnGeneratedKeys);


### PR DESCRIPTION
Fixes #27: During startup: "java.sql.SQLException: statement is not executing"